### PR TITLE
Allow poorly formated .excalidraw files to render

### DIFF
--- a/src/ExcalidrawData.ts
+++ b/src/ExcalidrawData.ts
@@ -518,7 +518,7 @@ export class ExcalidrawData {
       return;
     }
 
-    const saveVersion = this.scene.source.split("https://github.com/zsviczian/obsidian-excalidraw-plugin/releases/tag/")[1]??"1.8.16";
+    const saveVersion = this.scene.source?.split("https://github.com/zsviczian/obsidian-excalidraw-plugin/releases/tag/")[1]??"1.8.16";
 
     const elements = this.scene.elements;
     for (const el of elements) {


### PR DESCRIPTION
There are several excalidraw implementations which fail to follow the defined excalidraw JSON schema. This allows those poorly formatted files to render in legacy mode in Obsidian.